### PR TITLE
Aggregation of purge logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After you have created the tables above, the list of CHT instances to scrape is 
 
 * To add a new instance, insert a row into the table
 * To disable an instance, set `enabled` to `false`
-* To scrape deep metrics for an instance, set `access-level` to `1`, `2`, `3` or `4`
+* To scrape deep metrics for an instance, set `access-level` to `1`, `2`, or `3`
 
 ### Credentials
 
@@ -113,7 +113,7 @@ After you have set up your `.env` per above, run `docker-compose up`.  All relat
 
 ## Output
 
-As the `access-level` of the user increases from `1` up to `4`, richer metrics are available. The results of the scraped data are stored in Postgres tables:
+As the `access-level` of the user increases from `1` up to `3`, richer metrics are available. The results of the scraped data are stored in Postgres tables:
 
 table | doctype | description
 -- | -- | --
@@ -121,7 +121,6 @@ monitoring_docs | settings | [app_settings.json](https://docs.communityhealthtoo
 monitoring_docs | monitoring | Result from [Monitoring API v1](https://docs.communityhealthtoolkit.org/apps/reference/api/#get-apiv1monitoring)
 monitoring_docs | analysis | See [Analysis](#analysis)
 monitoring_docs | error | An error occurred while scraping the instance. Document contains error
-monitoring_logs | - | [Purging logs and errors](https://docs.communityhealthtoolkit.org/apps/guides/performance/purging/#purged-documents-server-side)
 
 ### Access Level 1
 
@@ -130,7 +129,6 @@ Access Level | Access Requirement | Output
 1 | Anonymous | Monitoring API Only
 2 | Offline User | Basic (Analysis)[#analysis]
 3 | Online User | Full (Analysis)[#analysis]
-4 | Access to Sentinel Logs | Purging logs
 
 ### Access Level 2
 
@@ -161,10 +159,6 @@ Access Level | Access Requirement | Output
 ### Access Level 3
 
 Access Level `2` but add role `mm-online`. This gives the user access to all data on the instance.
-
-### Access Level 4
-
-Access Level `3` and alter `/medic-sentinel/_security` setting `members.roles` to include `app_monitoring`. 
 
 ### Analysis
 

--- a/pg-warehouse.js
+++ b/pg-warehouse.js
@@ -49,10 +49,6 @@ class PostgresWarehouse {
     await queryInsertDoc(this.client, result.urlId, 'settings', result.settings);
     await queryInsertDoc(this.client, result.urlId, 'monitoring', result.monitoring);
     await queryInsertDoc(this.client, result.urlId, 'klipfolio_datasource', result.klipDatasources);
-
-    for (const log of result.logs || []) {
-      await queryInsertLog(this.client, result.urlId, log);
-    }
   }
   
   async disconnect() {
@@ -81,12 +77,6 @@ const queryInsertDoc = async (client, urlId, docType, doc) => {
 
   console.log(`${result.rowCount} is inserted successfully`);
   return result;
-};
-
-const queryInsertLog = (client, urlId, log) => {
-  const query = `INSERT INTO monitoring_logs (url_id, doc_id, doc) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT monitoring_logs_idx_constraint DO NOTHING;`;
-  const insertParams = [urlId, log._id, JSON.stringify(log)];
-  return client.query(query, insertParams);
 };
 
 module.exports = PostgresWarehouse;

--- a/postgres/db_schema.sql
+++ b/postgres/db_schema.sql
@@ -22,20 +22,3 @@ CREATE TABLE public.monitoring_docs (
       REFERENCES monitoring_urls(id)
 );
 ALTER TABLE public.monitoring_docs OWNER TO full_access;
-
-CREATE TABLE public.monitoring_logs (
-  id SERIAL PRIMARY KEY,
-  url_id INTEGER NOT NULL,
-  created TIMESTAMP DEFAULT NOW(),
-  doc_id VARCHAR NOT NULL,
-  doc JSONB NOT NULL,
-  CONSTRAINT fk_url
-    FOREIGN KEY(url_id)
-      REFERENCES monitoring_urls(id)
-);
-ALTER TABLE public.monitoring_logs OWNER TO full_access;
-
--- This constraint is used for upsert
--- `ON CONFLICT ON CONSTRAINT monitoring_logs_idx_constraint DO NOTHING`
-CREATE UNIQUE INDEX monitoring_logs_idx ON monitoring_logs(url_id, doc_id);
-ALTER TABLE monitoring_logs ADD CONSTRAINT monitoring_logs_idx_constraint UNIQUE USING INDEX monitoring_logs_idx;

--- a/postgres/functions/get_purge_logs.sql
+++ b/postgres/functions/get_purge_logs.sql
@@ -30,7 +30,9 @@ SELECT
   (doc ->> ''skipped_contacts'')::text as skipped_contacts,
   doc ->> ''error'' as error
 FROM couchdb
-WHERE doc #>> ''{_id}'' like ''purgelog:%''
+WHERE
+  doc #>> ''{_id}'' like ''purgelog:%''
+  AND (doc ->> ''date'')::timestamptz > now() - ''120 days''::interval
 ;
             ',
             FALSE

--- a/postgres/functions/get_purge_logs.sql
+++ b/postgres/functions/get_purge_logs.sql
@@ -1,0 +1,41 @@
+DROP FUNCTION IF EXISTS get_purge_logs();
+
+CREATE OR REPLACE FUNCTION get_purge_logs() RETURNS TABLE(partner text, completion_date timestamptz, duration_minutes int, skipped_contacts text, error text) AS $$
+DECLARE partners cursor IS (
+        SELECT DISTINCT ON (partner_name)
+            partner_name AS name,
+            port
+        FROM impactconfig
+        WHERE close_date IS NULL
+    );
+DECLARE credentials record;
+BEGIN 
+    SELECT value->>'user' AS user, value->>'password' AS password FROM configuration WHERE KEY = 'dblink' INTO credentials;
+    FOR partner IN partners LOOP RETURN query
+    SELECT
+        *
+    FROM dblink(
+            FORMAT(
+                'dbname=%s host=localhost port=%s user=%s password=%s',
+                partner.name,
+                partner.port,
+                credentials.user,
+                credentials.password
+            ),
+            '
+SELECT
+  current_database() as partner,
+  (doc ->> ''date'')::timestamptz as completion_date,
+  ((doc ->> ''duration'')::double precision / 1000 / 60)::integer as duration_minutes,
+  (doc ->> ''skipped_contacts'')::text as skipped_contacts,
+  doc ->> ''error'' as error
+FROM couchdb
+WHERE doc #>> ''{_id}'' like ''purgelog:%''
+;
+            ',
+            FALSE
+        ) tasks(partner text, completion_date timestamptz, duration_minutes int, skipped_contacts text, error text);
+END LOOP;
+END;
+$$ language plpgsql
+;

--- a/postgres/matviews/purge_logs.sql
+++ b/postgres/matviews/purge_logs.sql
@@ -1,0 +1,13 @@
+DROP MATERIALIZED VIEW if EXISTS app_monitoring_purge_logs;
+CREATE MATERIALIZED VIEW app_monitoring_purge_logs AS (
+    SELECT
+        fn.partner AS partner_name,
+        fn.completion_date,
+        duration_minutes,
+        skipped_contacts,
+        error
+    FROM
+        get_purge_logs() fn
+);
+ALTER MATERIALIZED VIEW app_monitoring_purge_logs OWNER TO full_access;
+GRANT SELECT ON app_monitoring_purge_logs TO superset;

--- a/scrape-instance.js
+++ b/scrape-instance.js
@@ -21,7 +21,7 @@ const scrape = async instance => {
     const monitoring = await fetchWithoutAuth(url, '/api/v1/monitoring');
     console.log(`Monitor for ${url}: ${!!monitoring}`);
 
-    let settings, klipDatasources, forms, users, analysis, logs;
+    let settings, klipDatasources, forms, users, analysis;
     if (instance.klipfolioClientId) {
       klipDatasources = await fetchKlipDatasourceStatus(instance.klipfolioClientId, instance.klipfolioApiKey);
     }
@@ -40,13 +40,6 @@ const scrape = async instance => {
       console.log(`Successful analysis of ${url}...`);
     }
 
-    // user account with online role and access to medic-sentinel
-    if (instance.access > 3) {
-      const timestampOneMonthAgo = new Date().getTime() - 30 * 24 * 60 * 60 * 1000;
-      const fetched = await fetchWithAuth(url, instance, `/medic-sentinel/_all_docs?startkey=%22purgelog:${timestampOneMonthAgo}%22&endkey=%22purgelog:\\ufff0%22&include_docs=true`);
-      logs = fetched.rows.map(row => row.doc);
-    }
-
     return {
       urlId: instance.urlId,
       status: 'ok',
@@ -54,7 +47,6 @@ const scrape = async instance => {
       klipDatasources,
       monitoring,
       analysis,
-      logs,
     };
   } catch (e) {
     console.log(`CRASH`, e);


### PR DESCRIPTION
Today the app-monitoring-data-ingest tool supports custom JavaScript steps and required permissions to retrieve a project's _purgelogs_. This proposes a more streamlined approach in which we rely on sentinel logs being synced to Postgres. Under this simpler approach _purgelogs_ can be pulled through standard Postgres queries. 

This PR proposes:

1. Add standard Postgres function/matview pair to aggregate purgelogs for all projects
2. Removes all custom code to scrape purgelogs into the `monitoring_logs` table

Removal of custom code includes three pieces:
1. Remove JavaScript code for scraping purgelogs
2. Remove access-level four
3. Remove `monitoring_logs` database table
4. Documentation updates

#13 

_This is technically a breaking change but I believe this is the right time to make it since I believe this tool only has one user at this time and the features being removed are unused._