### PR TITLE
Ignore couchdb_progress for redundant sources

### DIFF
--- a/postgres/functions/monitoring_ingest_couchpg_seqs.sql
+++ b/postgres/functions/monitoring_ingest_couchpg_seqs.sql
@@ -25,12 +25,14 @@ BEGIN
                 credentials.user,
                 credentials.password
               ), 
-'select
-  current_database() as partner_name,
-  date_trunc(''day'', now()) as created,
-  split_part(seq, ''-'', 1) as seq,
-  split_part(source, ''/'', 2) as source
-from couchdb_progress;',
+'SELECT
+  current_database() AS partner_name,
+  date_trunc(''day'', now()) AS created,
+  split_part(seq, ''-'', 1) AS seq,
+  split_part(source, ''/'', 2) AS source
+FROM couchdb_progress
+WHERE seq != ''0''
+;',
               FALSE
           ) couchdb_progress(partner_name text, created date, seq bigint, source text)
       ON CONFLICT ON CONSTRAINT monitoring_couchpg_idx_constraint DO NOTHING


### PR DESCRIPTION
#68 

I'm not sure how the `couchdb_progress` table got to include multiple duplicate entries like `disc-mali.ml:443/medic` and `disc-mali.ml/medic` but that is our current state. I imagine this is because somebody ran couch2pg in a non-standard config against production.

Seq | Source
-- | --
0 | disc-mali.ml:443/medic
0 | disc-mali.ml/medic2
95881-g1AAAAO1e | disc-mali.ml/medic
130945-g1AAAAO1 | disc-mali.ml/medic-sentinel
484-g1AAAAOReJy | disc-mali.ml/medic-users-meta

The proposed fix is to assume this is one-off issue and ignore these entries. An alternative solution would be to somehow group by source and disambiguate. I'm inclined toward the simple option. 