### PR TITLE
flitrate data source with refresh_interval is never

### DIFF
--- a/postgres/matviews/klipfolio_datasource_refresh.sql
+++ b/postgres/matviews/klipfolio_datasource_refresh.sql
@@ -23,6 +23,7 @@ CREATE MATERIALIZED VIEW app_monitoring_klipfolio_datasource_refresh AS
     COUNT(*) FILTER ( WHERE refresh_age > refresh_interval )/total_datasources AS percent_failed_refresh
   FROM refresh_age_CTE AS docs
   LEFT JOIN monitoring_urls AS partners ON (partners.id = docs.url_id)
+  WHERE refresh_interval <> 0
   GROUP by docs.id, created, total_datasources, partner_name;
 
 CREATE UNIQUE INDEX IF NOT EXISTS app_monitoring_klipfolio_datasource_refresh_id_created_partner_name ON app_monitoring_klipfolio_datasource_refresh USING btree(id, created, partner_name);


### PR DESCRIPTION
[#38](https://github.com/medic/cht-app-monitoring-data-ingest/issues/38)
 I noticed that the static data sources have a value of 0 on refresh_interval. So I think we can make a filter based on this variable.