### PR TITLE
Rely on useviews from couch2pg@v3.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,7 @@ appSettingRevs | Number of revisions to the `settings` document. This number cha
 formRevs | Number of revisions to form documents. This number changes once per form each time `medic-conf upload-app-forms upload-contact-forms` has an effect
 permission.* | Number of users with this permission (Access Level 3 required)
 transitions.* | True if the transition is enabled for this project
+
+## Dependencies
+
+Monitors projects using cht-couch2pg v3.6.2 and above.

--- a/postgres/functions/get_forms_by_completion.sql
+++ b/postgres/functions/get_forms_by_completion.sql
@@ -29,61 +29,18 @@ BEGIN
         creds.password
     ),
         '
-WITH telemetry_docs_with_metric_blob AS (
-  SELECT
-    doc->> ''_id'' AS id,
-    concat_ws(
-      ''-''::text, doc #>> ''{metadata,year}'',
-      CASE
-          WHEN
-            doc #>> ''{metadata,day}'' IS NULL -- some telemetry documents have version 3.4, but have the modern daily metadata
-            AND (
-              doc #>> ''{metadata,versions,app}'' IS NULL or 
-              string_to_array("substring"(doc #>> ''{metadata,versions,app}'', ''(\d+.\d+.\d+)''), ''.'')::integer[] < ''{3,8,0}''::integer[]
-            )
-          THEN ((doc #>> ''{metadata,month}'')::integer) + 1
-          ELSE (doc #>> ''{metadata,month}'')::integer
-      END,
-      CASE
-          WHEN (doc #>> ''{metadata,day}'') IS NOT NULL
-          THEN doc #>> ''{metadata,day}''
-          ELSE ''1''::text
-      END
-    )::date AS period_start,
-    jsonb_object_keys(doc->''metrics'') AS metric,
-    doc->''metrics''->jsonb_object_keys(doc->''metrics'') AS metric_values
-  FROM couchdb_users_meta
-  WHERE
-    doc ->> ''type'' = ''telemetry''
-),
-
-telemetry_metrics AS (
-  SELECT 
-    id,
-    period_start,
-    metric,
-    min,
-    max,
-    sum,
-    count,
-    sumsqr
-  FROM telemetry_docs_with_metric_blob
-  CROSS JOIN LATERAL jsonb_to_record(metric_values) AS (min decimal, max decimal, sum decimal, count bigint, sumsqr decimal)
-)
-
 SELECT
   current_database() AS partner,
   split_part(metric, '':'', 3) AS form_name,
   COALESCE(SUM(count) filter (WHERE metric LIKE ''%:render''), 0) AS load_count,
   COALESCE(SUM(count) filter (WHERE metric LIKE ''%:save''), 0) AS complete_count,
 
-  
   -- this percentile is misrepresentative for any project with monthly telemetry docs
   -- same performance as percentile_disc(array[0.1, 0.5, 0.9])
   percentile_disc(0.1) within group (order by COALESCE(sum, 0) / count) filter (where metric like ''%:user_edit_time'') as completion_time_10percentile,
   percentile_disc(0.5) within group (order by COALESCE(sum, 0) / count) filter (where metric like ''%:user_edit_time'') as completion_time_50percentile,
   percentile_disc(0.9) within group (order by COALESCE(sum, 0) / count) filter (where metric like ''%:user_edit_time'') as completion_time_90percentile
-FROM telemetry_metrics
+FROM useview_telemetry_metrics
 WHERE
   period_start >= now() - ''60 days''::interval
   and metric LIKE ''enketo:%'' AND metric LIKE ''%:add:%''

--- a/postgres/functions/get_initial_replications.sql
+++ b/postgres/functions/get_initial_replications.sql
@@ -29,37 +29,7 @@ BEGIN
         creds.password
     ),
         '
-WITH useview_telemetry_devices AS (
-  SELECT
-    DISTINCT ON (doc #>> ''{metadata,deviceId}'', doc #>> ''{metadata,user}'')
-    doc #>> ''{metadata,deviceId}'' AS device_id,
-    doc #>> ''{metadata,user}'' AS user_name,
-    
-    concat_ws(
-      ''-'',
-      doc #>> ''{metadata,year}'',
-      CASE
-        WHEN 
-          doc #>> ''{metadata,day}'' IS NULL 
-          AND (
-            doc #>> ''{metadata,versions,app}'' IS NULL 
-            OR string_to_array("substring"(doc #>> ''{metadata,versions,app}'', ''(\d+.\d+.\d+)''), ''.'')::integer[] < ''{3,8,0}''::integer[]
-          ) 
-        THEN (doc #>> ''{metadata,month}'')::integer + 1
-        ELSE (doc #>> ''{metadata,month}'')::integer
-      END,
-      CASE
-        WHEN doc #>> ''{metadata,day}'' IS NOT NULL 
-        THEN doc #>> ''{metadata,day}''
-        ELSE ''1''
-      END
-    )::date AS period_start
-  FROM couchdb_users_meta
-  WHERE doc ->> ''type'' = ''telemetry''
-  ORDER BY 1, 2, 3 ASC
-),
-
-dates AS (
+WITH dates AS (
   SELECT generate_series(now() - ''60 days''::interval, now(), ''1 day''::interval)::date AS date
 )
 

--- a/postgres/functions/get_replication_by_status.sql
+++ b/postgres/functions/get_replication_by_status.sql
@@ -29,48 +29,6 @@ BEGIN
         creds.password
     ),
         '
-WITH telemetry_docs_with_metric_blob AS (
-  SELECT
-    doc->> ''_id'' AS id,
-    concat_ws(
-      ''-''::text, doc #>> ''{metadata,year}'',
-      CASE
-          WHEN
-            doc #>> ''{metadata,day}'' IS NULL -- some telemetry documents have version 3.4, but have the modern daily metadata
-            AND (
-              doc #>> ''{metadata,versions,app}'' IS NULL or 
-              string_to_array("substring"(doc #>> ''{metadata,versions,app}'', ''(\d+.\d+.\d+)''), ''.'')::integer[] < ''{3,8,0}''::integer[]
-            )
-          THEN ((doc #>> ''{metadata,month}'')::integer) + 1
-          ELSE (doc #>> ''{metadata,month}'')::integer
-      END,
-      CASE
-          WHEN (doc #>> ''{metadata,day}'') IS NOT NULL
-          THEN doc #>> ''{metadata,day}''
-          ELSE ''1''::text
-      END
-    )::date AS period_start,
-    jsonb_object_keys(doc->''metrics'') AS metric,
-    doc->''metrics''->jsonb_object_keys(doc->''metrics'') AS metric_values
-  FROM couchdb_users_meta
-  WHERE
-    doc ->> ''type'' = ''telemetry''
-),
-
-telemetry_metrics AS (
-  SELECT 
-    id,
-    period_start,
-    metric,
-    min,
-    max,
-    sum,
-    count,
-    sumsqr
-  FROM telemetry_docs_with_metric_blob
-  CROSS JOIN LATERAL jsonb_to_record(metric_values) AS (min decimal, max decimal, sum decimal, count bigint, sumsqr decimal)
-)
-
 SELECT
   current_database() AS partner,
   period_start,
@@ -78,7 +36,7 @@ SELECT
   COALESCE(SUM(count) filter(where metric LIKE ''%:medic:%:failure''), 0) AS replication_failure_count,
   COALESCE(SUM(count) filter(where metric LIKE ''%:medic:%:denied''), 0) AS replication_denied_count,
   COALESCE(SUM(count) filter(where metric LIKE ''%:failure:reason:error''), 0) AS replication_error_count
-FROM telemetry_metrics
+FROM useview_telemetry_metrics
 WHERE
   period_start >= now() - ''60 days''::interval
   and metric like ''replication:%''


### PR DESCRIPTION
#89 

cht-couch2pg added `useview_telemetry_metrics` and `useview_telemetry_devices`. The rollout cht-couch2pg@v3.6.2 is finishing up. Once complete, we can get a significant performance boost by relying on these useview.